### PR TITLE
Differentiate OnItemActivate block selections so they don't interfere wi...

### DIFF
--- a/assets/prefabs/buildMaze.prefab
+++ b/assets/prefabs/buildMaze.prefab
@@ -11,5 +11,6 @@
   	"BuildMaze" : {
   	    blockType = "core:dirt"
   	},
-    "BlockSelection" : {}
+    "BlockSelection" : {},
+    "OnItemActivateSelection" : {}
 }


### PR DESCRIPTION
Currently the block selection tool system intercepts all BlockSelections and messes with them.
This patch adds a new OnItemActivateSelectionComponent.java to identify just item selection tools.
Enabled for the maze module.
